### PR TITLE
Add Basic REPL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versioning based on [LuaRocks rockspec](https://github.com/luarocks/luarocks/wik
 ### Fixed
 
 - Fix assignment operator compiled operation
+- Throw error when `return` statement is not the last statement in a block
 
 ### Removed
 

--- a/RELEASE_TODO.md
+++ b/RELEASE_TODO.md
@@ -1,6 +1,6 @@
 - Update version
   - Change version in erde rockspec (version + source.tag)
-  - Change version in cli (`erde --version`)
+  - Change version in erde.constants
 - Update Changelog
   - Change `UNRELEASED` to current date
   - Add next version section with UNRELEASED

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,8 @@
 # 0.3-2
 
 - add CLI REPL
-- add `finally` block
+- add tests for external parens (to throw away unused values)
+  - ex) `return (myfunc())`
 
 # 1.0-1
 
@@ -25,3 +26,5 @@
   - ex) `"hello %s":format(name)`
 - Allow arbitrary first parameter injection syntax
   - ex) `mytable::filter(() -> true)` == `filter(mytable, () -> true)`
+- Allow assignments in branches (if, elseif, with)
+  - ex) `if myvar = someFunc() { ... }` => `do { local myvar = someFunc() if myvar { ... } }`

--- a/TODO.md
+++ b/TODO.md
@@ -17,6 +17,8 @@
 
 # Possible Future Subprojects
 
+- add types to all internal errors
+  - remove need to backslash in repl. Instead, continue user input if error is EOL error
 - checker
   - check correct syntax
   - undeclared variables

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
 - add CLI REPL
 - add tests for external parens (to throw away unused values)
   - ex) `return (myfunc())`
+- improve error messages (mimic lua)
 
 # 1.0-1
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,26 +1,24 @@
 # TODO
 
-# 0.3-1
-
-- release!
-
 # 0.3-2
 
 - add CLI REPL
+- add `finally` block
 
 # 1.0-1
 
 - rewrite erde in erde
 
-# Possible Future Subprojects
+# 1.0-2
 
 - formatter
-- reverse compiler (compile Lua to Erde)
-- linter
+
+# Possible Future Subprojects
+
+- checker
+  - check correct syntax
   - undeclared variables
-  - unitialized variable
   - etc (see https://github.com/lunarmodules/luacheck)
-- language server
 
 # Possible Language Features (needs further discussion)
 - Allow strings / tables as index chain bases

--- a/TODO.md
+++ b/TODO.md
@@ -2,10 +2,12 @@
 
 # 0.3-2
 
-- add CLI REPL
-- add tests for external parens (to throw away unused values)
-  - ex) `return (myfunc())`
 - improve error messages (mimic lua)
+
+# 0.3-3
+
+- add types to all internal errors
+  - remove need for backslash in repl. Instead, continue user input if error is EOL error
 
 # 1.0-1
 
@@ -17,8 +19,6 @@
 
 # Possible Future Subprojects
 
-- add types to all internal errors
-  - remove need to backslash in repl. Instead, continue user input if error is EOL error
 - checker
   - check correct syntax
   - undeclared variables

--- a/bin/erde
+++ b/bin/erde
@@ -215,11 +215,11 @@ local function runFile(filePath)
       if type(err) == 'table' and err.__is_erde_error__ then
         return err.stacktrace
       elseif not utils.fileExists(filePath) then
-        return 'file does not exist: ' .. filePath
+        return 'File does not exist: ' .. filePath
       else
         return table.concat({
-          'internal error: ' .. tostring(err),
-          'please report this at: https://github.com/erde-lang/erde/issues',
+          'Internal error: ' .. tostring(err),
+          'Please report this at: https://github.com/erde-lang/erde/issues',
         }, '\n')
       end
     end

--- a/bin/erde
+++ b/bin/erde
@@ -251,7 +251,7 @@ if args.debug then
 end
 
 if args.version then
-  print('0.3-1')
+  print(C.VERSION)
 elseif args.run then
   lib.load()
   runFile(args.script)

--- a/bin/erde
+++ b/bin/erde
@@ -5,6 +5,7 @@ local lfs = require('lfs')
 local C = require('erde.constants')
 local compile = require('erde.compile')
 local lib = require('erde.lib')
+local repl = require('erde.repl')
 local utils = require('erde.utils')
 
 local load = loadstring or load
@@ -259,5 +260,5 @@ elseif args.compile then
 elseif args.clean then
   traverseLuaFiles(#args.paths > 0 and args.paths or { '.' }, cleanFile)
 else
-  print('repl not support yet')
+  repl()
 end

--- a/erde-0.3-1.rockspec
+++ b/erde-0.3-1.rockspec
@@ -17,6 +17,7 @@ dependencies = {
   'lua >= 5.1, <= 5.4',
   'argparse',
 	'luafilesystem',
+  'readline',
 }
 
 source = {

--- a/erde-0.3-1.rockspec
+++ b/erde-0.3-1.rockspec
@@ -17,7 +17,6 @@ dependencies = {
   'lua >= 5.1, <= 5.4',
   'argparse',
 	'luafilesystem',
-  'readline',
 }
 
 source = {

--- a/erde/compile.lua
+++ b/erde/compile.lua
@@ -815,6 +815,10 @@ local function Return()
   local compileLines = { currentTokenLine, consume() }
   local firstReturn = Try(Expr)
 
+  if isModuleReturnBlock then
+    hasModuleReturn = true
+  end
+
   if firstReturn then
     insert(compileLines, firstReturn)
     if currentToken == ',' then
@@ -825,6 +829,14 @@ local function Return()
     insert(compileLines, Parens(true, false, function()
       return weave(List(false, true, Expr), ',')
     end))
+  end
+
+  if blockDepth == 1 then
+    if currentToken then
+      error('expected <eof>')
+    end
+  elseif currentToken ~= '}' then
+    error('unexpected token: ', currentToken)
   end
 
   return compileLines
@@ -918,7 +930,6 @@ function Block(isLoopBlock)
     elseif currentToken == 'try' then
       insert(compileLines, TryCatch())
     elseif currentToken == 'return' then
-      if isModuleReturnBlock then hasModuleReturn = true end
       insert(compileLines, Return())
     elseif currentToken == 'function' then
       insert(compileLines, Function())

--- a/erde/constants.lua
+++ b/erde/constants.lua
@@ -1,5 +1,7 @@
 local C = {}
 
+C.VERSION = '0.3-1'
+
 -- Get the current platform path separator. Note that while this is undocumented
 -- in the Lua 5.1 manual, it is indeed supported in 5.1+.
 --

--- a/erde/lib.lua
+++ b/erde/lib.lua
@@ -203,6 +203,7 @@ local function __erde_internal_load_source__(sourceCode, sourceAlias)
       or compiled
 
     utils.erdeError({
+      type = 'compile',
       message = message,
       -- Use 3 levels to the traceback to account for the wrapping anonymous
       -- function above (in pcall) as well as the erde loader itself.
@@ -221,10 +222,13 @@ local function __erde_internal_load_source__(sourceCode, sourceAlias)
   local sourceLoader, err = load(compiled, erdeSourceId)
 
   if err ~= nil then
-    error(table.concat({
-      'failed to load compiled code',
-      'lua: ' .. tostring(err),
-    }, '\n'), 0)
+    utils.erdeError({
+      type = 'run',
+      message = table.concat({
+        'failed to load compiled code: ' .. tostring(err),
+        'please report this at: https://github.com/erde-lang/erde/issues',
+      }, '\n'),
+    })
   end
 
   local ok, result = xpcall(sourceLoader, function(message)
@@ -234,6 +238,7 @@ local function __erde_internal_load_source__(sourceCode, sourceAlias)
     else
       message = rewrite(message, sourceMap, sourceAlias)
       return {
+        type = 'run',
         message = message,
         -- Add an extra level to the traceback to account for the wrapping
         -- anonymous function above (in xpcall).

--- a/erde/lib.lua
+++ b/erde/lib.lua
@@ -225,8 +225,19 @@ local function __erde_internal_load_source__(sourceCode, sourceAlias)
     utils.erdeError({
       type = 'run',
       message = table.concat({
-        'failed to load compiled code: ' .. tostring(err),
-        'please report this at: https://github.com/erde-lang/erde/issues',
+        'Failed to load compiled code:',
+        tostring(err),
+        '',
+        'This is an internal error that should never happen.',
+        'Please report this at: https://github.com/erde-lang/erde/issues',
+        '',
+        'erde',
+        '----',
+        sourceCode,
+        '',
+        'lua',
+        '---',
+        compiled,
       }, '\n'),
     })
   end

--- a/erde/repl.lua
+++ b/erde/repl.lua
@@ -2,6 +2,13 @@ local RL = require('readline')
 local lib = require('erde.lib')
 
 local PROMPT = '> '
+local SUB_PROMPT = '>> '
+
+local SURROUND_OPENING_CHARS = { ['('] = ')', ['{'] = '}', ['['] = ']' }
+local SURROUND_CLOSING_CHARS = { [')'] = '(', ['}'] = '{', [']'] = '[' }
+
+local surroundCounters = { ['('] = 0, ['{'] = 0, ['['] = 0 }
+local needsSubPrompt = false
 
 RL.set_readline_name('erde')
 RL.set_options({
@@ -11,11 +18,46 @@ RL.set_options({
   auto_add = false,
 })
 
+local function updateSurroundCounters(line)
+  for i = 1, #line do
+    local char = line:sub(i, i)
+    if SURROUND_OPENING_CHARS[char] ~= nil then
+      surroundCounters[char] = surroundCounters[char] + 1
+    elseif SURROUND_CLOSING_CHARS[char] ~= nil then
+      local openingChar = SURROUND_CLOSING_CHARS[char]
+      surroundCounters[openingChar] = math.max(0, surroundCounters[openingChar] - 1)
+    end
+  end
+
+  needsSubPrompt = false
+  for char, counter in pairs(surroundCounters) do
+    if counter > 0 then
+      needsSubPrompt = true
+      break
+    end
+  end
+end
+
 return function()
   repeat
     local line = RL.readline(PROMPT)
+
     if line and #line > 0 then
+      updateSurroundCounters(line)
+
+      if needsSubPrompt then
+        repeat
+          local subLine = RL.readline(SUB_PROMPT)
+          updateSurroundCounters(subLine)
+          line = line .. '\n' .. subLine
+        until not needsSubPrompt or not subLine
+      end
+
       RL.add_history(line)
+      needsSubPrompt = false
+      for char in pairs(surroundCounters) do
+        surroundCounters[char] = 0
+      end
 
       -- Try expressions first! This way we can still print the value in the
       -- case that the expression is also a valid block (i.e. function calls).

--- a/erde/repl.lua
+++ b/erde/repl.lua
@@ -1,14 +1,13 @@
 local RL = require('readline')
+local C = require('erde.constants')
 local lib = require('erde.lib')
 
 local PROMPT = '> '
 local SUB_PROMPT = '>> '
 
+-- TODO support strings
 local SURROUND_OPENING_CHARS = { ['('] = ')', ['{'] = '}', ['['] = ']' }
 local SURROUND_CLOSING_CHARS = { [')'] = '(', ['}'] = '{', [']'] = '[' }
-
-local surroundCounters = { ['('] = 0, ['{'] = 0, ['['] = 0 }
-local needsSubPrompt = false
 
 RL.set_readline_name('erde')
 RL.set_options({
@@ -18,7 +17,7 @@ RL.set_options({
   auto_add = false,
 })
 
-local function updateSurroundCounters(line)
+local function updateSurroundCounters(line, surroundCounters)
   for i = 1, #line do
     local char = line:sub(i, i)
     if SURROUND_OPENING_CHARS[char] ~= nil then
@@ -29,61 +28,66 @@ local function updateSurroundCounters(line)
     end
   end
 
-  needsSubPrompt = false
   for char, counter in pairs(surroundCounters) do
     if counter > 0 then
-      needsSubPrompt = true
-      break
+      return true
     end
+  end
+
+  return false
+end
+
+local function getLine()
+  local line = RL.readline(PROMPT)
+
+  if line and #line > 0 then
+    local surroundCounters = { ['('] = 0, ['{'] = 0, ['['] = 0 }
+    local needsSubPrompt = updateSurroundCounters(line, surroundCounters)
+
+    if needsSubPrompt then
+      repeat
+        local subLine = RL.readline(SUB_PROMPT)
+        needsSubPrompt = updateSurroundCounters(subLine, surroundCounters)
+        line = line .. '\n' .. subLine
+      until not needsSubPrompt or not subLine
+    end
+
+    RL.add_history(line)
+    return line
   end
 end
 
 return function()
-  repeat
-    local line = RL.readline(PROMPT)
+  print('erde ' .. C.VERSION .. '  Copyright (C) 2021-2022 bsuth')
+  local line = getLine()
 
-    if line and #line > 0 then
-      updateSurroundCounters(line)
-
-      if needsSubPrompt then
-        repeat
-          local subLine = RL.readline(SUB_PROMPT)
-          updateSurroundCounters(subLine)
-          line = line .. '\n' .. subLine
-        until not needsSubPrompt or not subLine
+  while line do
+    -- Try expressions first! This way we can still print the value in the
+    -- case that the expression is also a valid block (i.e. function calls).
+    local exprOk, exprResult = pcall(function() return lib.run('return ' .. line, 'stdin') end)
+    
+    if exprOk then
+      if exprResult ~= nil then
+        print(exprResult)
       end
-
-      RL.add_history(line)
-      needsSubPrompt = false
-      for char in pairs(surroundCounters) do
-        surroundCounters[char] = 0
-      end
-
-      -- Try expressions first! This way we can still print the value in the
-      -- case that the expression is also a valid block (i.e. function calls).
-      local exprOk, exprResult = pcall(function() return lib.run('return ' .. line, 'stdin') end)
+    elseif exprResult.type ~= 'compile' then
+      print(exprResult.stacktrace)
+    else
+      local blockOk, blockResult = pcall(function() return lib.run(line, 'stdin') end)
       
-      if exprOk then
-        if exprResult ~= nil then
-          print(exprResult)
+      if blockOk then
+        if blockResult ~= nil then
+          print(blockResult)
         end
-      elseif exprResult.type ~= 'compile' then
-        print(exprResult.stacktrace)
+      elseif blockResult.type ~= 'compile' then
+        print(blockResult.stacktrace)
       else
-        local blockOk, blockResult = pcall(function() return lib.run(line, 'stdin') end)
-        
-        if blockOk then
-          if blockResult ~= nil then
-            print(blockResult)
-          end
-        elseif blockResult.type ~= 'compile' then
-          print(blockResult.stacktrace)
-        else
-          print('invalid syntax')
-          print('expr: ' .. tostring(exprResult))
-          print('block: ' .. tostring(blockResult))
-        end
+        print('invalid syntax')
+        print('expr: ' .. tostring(exprResult))
+        print('block: ' .. tostring(blockResult))
       end
     end
-  until not line
+
+    line = getLine()
+  end
 end

--- a/erde/repl.lua
+++ b/erde/repl.lua
@@ -1,0 +1,40 @@
+local lib = require('erde.lib')
+
+local PROMPT = '> '
+
+return function()
+  while true do
+    io.write(PROMPT)
+    local line = io.read()
+
+    if line == nil then
+      break
+    elseif #line > 0 then
+      -- Try expressions first! This way we can still print the value in the
+      -- case that the expression is also a valid block (i.e. function calls).
+      local exprOk, exprResult = pcall(function() return lib.run('return ' .. line, 'stdin') end)
+      
+      if exprOk then
+        if exprResult ~= nil then
+          print(exprResult)
+        end
+      elseif exprResult.type ~= 'compile' then
+        print(exprResult.stacktrace)
+      else
+        local blockOk, blockResult = pcall(function() return lib.run(line, 'stdin') end)
+        
+        if blockOk then
+          if blockResult ~= nil then
+            print(blockResult)
+          end
+        elseif blockResult.type ~= 'compile' then
+          print(blockResult.stacktrace)
+        else
+          print('invalid syntax')
+          print('expr: ' .. tostring(exprResult))
+          print('block: ' .. tostring(blockResult))
+        end
+      end
+    end
+  end
+end

--- a/erde/repl.lua
+++ b/erde/repl.lua
@@ -1,80 +1,66 @@
 local RL = require('readline')
 local C = require('erde.constants')
 local lib = require('erde.lib')
+local utils = require('erde.utils')
 
 local PROMPT = '> '
 local SUB_PROMPT = '>> '
 
--- TODO support strings
-local SURROUND_OPENING_CHARS = { ['('] = ')', ['{'] = '}', ['['] = ']' }
-local SURROUND_CLOSING_CHARS = { [')'] = '(', ['}'] = '{', [']'] = '[' }
-
-RL.set_readline_name('erde')
 RL.set_options({
   keeplines = 1000,
   histfile = '~/.erde_history',
   completion = false,
   auto_add = false,
 })
+RL.set_readline_name('erde')
 
-local function updateSurroundCounters(line, surroundCounters)
-  for i = 1, #line do
-    local char = line:sub(i, i)
-    if SURROUND_OPENING_CHARS[char] ~= nil then
-      surroundCounters[char] = surroundCounters[char] + 1
-    elseif SURROUND_CLOSING_CHARS[char] ~= nil then
-      local openingChar = SURROUND_CLOSING_CHARS[char]
-      surroundCounters[openingChar] = math.max(0, surroundCounters[openingChar] - 1)
-    end
+local function readLine(prompt)
+  local replLine = RL.readline(prompt)
+  if not replLine or replLine:match('^%s*$') then return end
+
+  local sourceLines = {}
+  local needsSubPrompt = false
+
+  -- Check all lines from readline in case user is reusing a previous multiline command
+  for _, line in pairs(utils.split(replLine, '\n')) do
+    table.insert(sourceLines, (line:gsub('\\%s*$', '')))
   end
 
-  for char, counter in pairs(surroundCounters) do
-    if counter > 0 then
-      return true
-    end
-  end
-
-  return false
-end
-
-local function getLine()
-  local line = RL.readline(PROMPT)
-
-  if line and #line > 0 then
-    local surroundCounters = { ['('] = 0, ['{'] = 0, ['['] = 0 }
-    local needsSubPrompt = updateSurroundCounters(line, surroundCounters)
-
-    if needsSubPrompt then
-      repeat
-        local subLine = RL.readline(SUB_PROMPT)
-        needsSubPrompt = updateSurroundCounters(subLine, surroundCounters)
-        line = line .. '\n' .. subLine
-      until not needsSubPrompt or not subLine
-    end
-
-    RL.add_history(line)
-    return line
-  end
+  return replLine, table.concat(sourceLines, '\n'), replLine:match('\\%s*$')
 end
 
 return function()
   print('erde ' .. C.VERSION .. '  Copyright (C) 2021-2022 bsuth')
-  local line = getLine()
+  print('Use trailing backslashes for multiline inputs.')
 
-  while line do
+  while true do
+    local replLine, sourceLine, needsSubPrompt = readLine(PROMPT)
+    if not replLine then break end
+
+    if needsSubPrompt then
+      repeat
+        local subReplLine, subSourceLine, needsSubPrompt = readLine(SUB_PROMPT)
+        if not subReplLine then break end
+        replLine = replLine .. '\n' .. subReplLine
+        sourceLine = sourceLine .. '\n' .. subSourceLine
+      until not needsSubPrompt
+    end
+
+    RL.add_history(replLine)
+
     -- Try expressions first! This way we can still print the value in the
     -- case that the expression is also a valid block (i.e. function calls).
-    local exprOk, exprResult = pcall(function() return lib.run('return ' .. line, 'stdin') end)
-    
+    local exprOk, exprResult = pcall(function() return lib.run('return ' .. sourceLine, 'stdin') end)
+
     if exprOk then
       if exprResult ~= nil then
         print(exprResult)
       end
     elseif exprResult.type ~= 'compile' then
-      print(exprResult.stacktrace)
+      print(exprResult.stacktrace or exprResult.message)
     else
-      local blockOk, blockResult = pcall(function() return lib.run(line, 'stdin') end)
-      
+      local blockOk, blockResult = pcall(function() return lib.run(sourceLine, 'stdin') end)
+
       if blockOk then
         if blockResult ~= nil then
           print(blockResult)
@@ -87,7 +73,5 @@ return function()
         print('block: ' .. tostring(blockResult))
       end
     end
-
-    line = getLine()
   end
 end

--- a/erde/repl.lua
+++ b/erde/repl.lua
@@ -1,15 +1,22 @@
+local RL = require('readline')
 local lib = require('erde.lib')
 
 local PROMPT = '> '
 
-return function()
-  while true do
-    io.write(PROMPT)
-    local line = io.read()
+RL.set_readline_name('erde')
+RL.set_options({
+  keeplines = 1000,
+  histfile = '~/.erde_history',
+  completion = false,
+  auto_add = false,
+})
 
-    if line == nil then
-      break
-    elseif #line > 0 then
+return function()
+  repeat
+    local line = RL.readline(PROMPT)
+    if line and #line > 0 then
+      RL.add_history(line)
+
       -- Try expressions first! This way we can still print the value in the
       -- case that the expression is also a valid block (i.e. function calls).
       local exprOk, exprResult = pcall(function() return lib.run('return ' .. line, 'stdin') end)
@@ -36,5 +43,5 @@ return function()
         end
       end
     end
-  end
+  until not line
 end

--- a/erde/tokenize.lua
+++ b/erde/tokenize.lua
@@ -40,7 +40,6 @@ end
 local function throw(message, errLine)
   utils.erdeError({
     message = message,
-    message = message,
     line = errLine or line,
   })
 end

--- a/spec/compile_spec.lua
+++ b/spec/compile_spec.lua
@@ -730,3 +730,16 @@ spec('ambiguous syntax 5.1+', function()
     return x
   ]])
 end)
+
+spec('retain throwaway parens', function()
+  assert.run(true, [[
+    local a = () -> (1, 2)
+    local x, y = (a())
+    return x == 1
+  ]])
+  assert.run(false, [[
+    local a = () -> (1, 2)
+    local x, y = (a())
+    return y == 2
+  ]])
+end)

--- a/spec/compile_spec.lua
+++ b/spec/compile_spec.lua
@@ -652,6 +652,17 @@ spec('return #5.1+', function()
       2,
     )
   ]])
+  assert.has_error(function()
+    compile('return 1 if true {}')
+  end)
+  assert.has_error(function()
+    compile([[
+      if true {
+        return 1
+        print(32)
+      }
+    ]])
+  end)
 end)
 
 spec('try catch #5.1+', function()


### PR DESCRIPTION
Adds basic REPL support when using `erde` as a standalone command.  Allows for the optional [readline](https://pjb.com.au/comp/lua/readline.html) dependency, which will be automatically loaded and used so long as it can be `require`'d