### PR TITLE
Print results in REPL like in Lua

### DIFF
--- a/erde/cli/repl.lua
+++ b/erde/cli/repl.lua
@@ -1,6 +1,8 @@
 local C = require('erde.constants')
 local lib = require('erde.lib')
 local utils = require('erde.utils')
+local pack = table.pack or pack
+local unpack = table.unpack or unpack
 
 local PROMPT = '> '
 local SUB_PROMPT = '>> '
@@ -45,7 +47,8 @@ local function repl()
       -- Try input as an expression first! This way we can still print the value
       -- in the case that the expression is also a valid block (i.e. function calls).
       ok, result = pcall(function()
-        return lib.run('return ' .. source, { alias = 'stdin' })
+        -- pack results so we know how many were actually returned even if there are nils among them
+        return pack(lib.run('return ' .. source, { alias = 'stdin' }))
       end)
 
       if not ok and type(result) == 'string' and not result:find('unexpected eof') then
@@ -66,7 +69,13 @@ local function repl()
     if not ok then
       print(lib.rewrite(result))
     elseif result ~= nil then
-      print(result)
+      -- in here `result` is a table that stores all values returned from input as expression case
+      local results = {}
+      for i = 1, result.n do
+        -- call tostring directly, so trailing nils are also serialized
+        results[i] = tostring(result[i])
+      end
+      print(unpack(results))
     end
 
     if HAS_READLINE and utils.trim(source) ~= '' then

--- a/erde/lib.lua
+++ b/erde/lib.lua
@@ -193,8 +193,7 @@ end
 -- IMPORTANT: THIS IS AN ERDE SOURCE LOADER AND MUST ADHERE TO THE USAGE SPEC OF
 -- `__erde_internal_load_source__`!
 local function run_string(source, options)
-  local result = { __erde_internal_load_source__(source, options) }
-  return unpack(result)
+  return __erde_internal_load_source__(source, options)
 end
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
I have played with REPL a little bit and attempted to get consistent behavior between Lua and Erde.

In REPL before:
```
$ erde
Erde 0.5-1 on Lua 5.4 -- Copyright (C) 2021-2023 bsuth
> f = () -> (nil, 2, nil)
> f()
> 
```

In REPL after:
```
$ erde
Erde 0.5-1 on Lua 5.4 -- Copyright (C) 2021-2023 bsuth
> f = () -> (nil, 2, nil)
> f()
nil	2	nil
>
```

Lua REPL for comparison:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> f = function() return nil, 2, nil end
> f()
nil	2	nil
> 

```

Additionally, it fixed return values from `erde.run`:
Before:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> erde = require('erde')
> erde.run('return nil, 2, nil')
nil	2
> 
```

After:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> erde = require('erde')
> erde.run('return nil, 2, nil')
nil	2	nil
> 
```