### PR TITLE
Print results in REPL like in Lua

### DIFF
--- a/erde/lib.lua
+++ b/erde/lib.lua
@@ -190,11 +190,14 @@ local function __erde_internal_load_source__(source, options)
   return loader()
 end
 
+local function source_loader_wrapper(...)
+  return ...
+end
+
 -- IMPORTANT: THIS IS AN ERDE SOURCE LOADER AND MUST ADHERE TO THE USAGE SPEC OF
 -- `__erde_internal_load_source__`!
 local function run_string(source, options)
-  local result = { __erde_internal_load_source__(source, options) }
-  return unpack(result)
+  return source_loader_wrapper(__erde_internal_load_source__(source, options))
 end
 
 -- -----------------------------------------------------------------------------


### PR DESCRIPTION
This is updated code from PR #12 but on separate branch.

Includes all review comments from original PR.

Original description for easier reference:

I have played with REPL a little bit and attempted to get consistent behavior between Lua and Erde.

In REPL before:
```
$ erde
Erde 0.5-1 on Lua 5.4 -- Copyright (C) 2021-2023 bsuth
> f = () -> (nil, 2, nil)
> f()
> 
```

In REPL after:
```
$ erde
Erde 0.5-1 on Lua 5.4 -- Copyright (C) 2021-2023 bsuth
> f = () -> (nil, 2, nil)
> f()
nil	2	nil
>
```

Lua REPL for comparison:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> f = function() return nil, 2, nil end
> f()
nil	2	nil
> 

```

Additionally, it fixed return values from `erde.run`:
Before:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> erde = require('erde')
> erde.run('return nil, 2, nil')
nil	2
> 
```

After:
```
$ lua
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
> erde = require('erde')
> erde.run('return nil, 2, nil')
nil	2	nil
> 
```