### PR TITLE
Add bitexpr + deprecate bitlib

### DIFF
--- a/erde/cli.erde
+++ b/erde/cli.erde
@@ -133,6 +133,7 @@ Options:
    -v, --version          Show version and exit.
    --bitexpr    <EXPR>    Expression to use for bit operations.
    -b, --bitlib <LIB>     Library to use for bit operations.
+                          DEPRECATED: Use --bitexpr instead.
    -t, --target <TARGET>  Lua target for version compatability.
                           Must be one of: { table.concat(VALID_LUA_TARGETS, ', ') }
 
@@ -467,6 +468,7 @@ while current_arg_index <= num_args {
   } elseif arg_value == '--bitexpr' {
     config.bitexpr = parse_option(arg_value)
   } elseif arg_value == '-b' || arg_value == '--bitlib' {
+    print("WARNING: `--bitlib` has been deprecated in favor of `--bitexpr`.")
     config.bitlib = parse_option(arg_value)
   } elseif arg_value:sub(1, 1) == '-' {
     terminate("Unrecognized option: { arg_value }")

--- a/erde/cli.erde
+++ b/erde/cli.erde
@@ -131,6 +131,7 @@ Commands:
 Options:
    -h, --help             Show this help message and exit.
    -v, --version          Show version and exit.
+   --bitexpr    <EXPR>    Expression to use for bit operations.
    -b, --bitlib <LIB>     Library to use for bit operations.
    -t, --target <TARGET>  Lua target for version compatability.
                           Must be one of: { table.concat(VALID_LUA_TARGETS, ', ') }
@@ -463,6 +464,8 @@ while current_arg_index <= num_args {
     }
   } elseif arg_value == '-o' || arg_value == '--outdir' {
     cli.outdir = parse_option(arg_value)
+  } elseif arg_value == '--bitexpr' {
+    config.bitexpr = parse_option(arg_value)
   } elseif arg_value == '-b' || arg_value == '--bitlib' {
     config.bitlib = parse_option(arg_value)
   } elseif arg_value:sub(1, 1) == '-' {

--- a/erde/cli.lua
+++ b/erde/cli.lua
@@ -115,6 +115,7 @@ Options:
    -v, --version          Show version and exit.
    --bitexpr    <EXPR>    Expression to use for bit operations.
    -b, --bitlib <LIB>     Library to use for bit operations.
+                          DEPRECATED: Use --bitexpr instead.
    -t, --target <TARGET>  Lua target for version compatability.
                           Must be one of: ]] .. tostring(table.concat(VALID_LUA_TARGETS, ", ")) .. [[
 
@@ -389,6 +390,7 @@ while current_arg_index <= num_args do
 	elseif arg_value == "--bitexpr" then
 		config.bitexpr = parse_option(arg_value)
 	elseif arg_value == "-b" or arg_value == "--bitlib" then
+		print("WARNING: `--bitlib` has been deprecated in favor of `--bitexpr`.")
 		config.bitlib = parse_option(arg_value)
 	elseif arg_value:sub(1, 1) == "-" then
 		terminate("Unrecognized option: " .. tostring(arg_value))

--- a/erde/cli.lua
+++ b/erde/cli.lua
@@ -113,6 +113,7 @@ Commands:
 Options:
    -h, --help             Show this help message and exit.
    -v, --version          Show version and exit.
+   --bitexpr    <EXPR>    Expression to use for bit operations.
    -b, --bitlib <LIB>     Library to use for bit operations.
    -t, --target <TARGET>  Lua target for version compatability.
                           Must be one of: ]] .. tostring(table.concat(VALID_LUA_TARGETS, ", ")) .. [[
@@ -385,6 +386,8 @@ while current_arg_index <= num_args do
 		end
 	elseif arg_value == "-o" or arg_value == "--outdir" then
 		cli.outdir = parse_option(arg_value)
+	elseif arg_value == "--bitexpr" then
+		config.bitexpr = parse_option(arg_value)
 	elseif arg_value == "-b" or arg_value == "--bitlib" then
 		config.bitlib = parse_option(arg_value)
 	elseif arg_value:sub(1, 1) == "-" then

--- a/erde/compile.erde
+++ b/erde/compile.erde
@@ -77,8 +77,8 @@ local alias
 -- Lua targets to support when generating compiled code.
 local lua_target
 
--- Resolved bit library to use for compiling bit operations.
-local bitlib
+-- Resolved bit expression to use for compiling bit operations.
+local bitexpr
 
 -- -----------------------------------------------------------------------------
 -- General Helpers
@@ -231,13 +231,13 @@ local function compile_binop(op_token, op_line, lhs, rhs) {
     -- SOURCEMAP: Handle incompatible argument types (`math.floor`)
     -- SOURCEMAP: Handle incompatible operand types (`/`)
     return { op_line, 'math.floor(', lhs, op_line, '/', rhs, ')' }
-  } elseif bitlib && BITOPS[op_token] {
-    -- NOTE: We wrap the bitlib call in parentheses to prevent tail calls in
+  } elseif bitexpr && BITOPS[op_token] {
+    -- NOTE: We wrap the bitop call in parentheses to prevent tail calls in
     -- LuaJIT, since any errors will have a misleading stacktrace.
     -- see: https://www.freelists.org/post/luajit/Bad-stack-trace-from-lua-getstack-and-lua-getinfo,1
     --
     -- SOURCEMAP: Handle incompatible argument types
-    return { op_line, "(require('{ bitlib }').{ BITLIB_METHODS[op_token] }(", lhs, ',', rhs, '))' }
+    return { op_line, "(({ bitexpr }).{ BITLIB_METHODS[op_token] }(", lhs, ',', rhs, '))' }
   } elseif op_token == '!=' {
     return { lhs, '~=', rhs }
   } elseif op_token == '==' {
@@ -1099,15 +1099,15 @@ local function unop_expression() {
   } elseif unop.token != '~' {
     -- SOURCEMAP: Handle incompatible operand types
     return { unop_line, unop.token, operand }
-  } elseif bitlib {
-    -- NOTE: We wrap the bitlib call in parentheses to prevent tail calls in
+  } elseif bitexpr {
+    -- NOTE: We wrap the bitop call in parentheses to prevent tail calls in
     -- LuaJIT, since any errors will have a misleading stacktrace.
     -- see: https://www.freelists.org/post/luajit/Bad-stack-trace-from-lua-getstack-and-lua-getinfo,1
     --
     -- SOURCEMAP: Handle incompatible argument types
-    return { unop_line, "(require('{ bitlib }').bnot(", operand, '))' }
+    return { unop_line, "(({ bitexpr }).bnot(", operand, '))' }
   } elseif lua_target == '5.1+' || lua_target == '5.2+' {
-    throw('must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+', unop_line)
+    throw('must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+', unop_line)
   } else {
     -- SOURCEMAP: Handle incompatible operand types
     return { unop_line, unop.token, operand }
@@ -1124,8 +1124,8 @@ function expression(min_prec = 1) {
   local binop_line, binop = current_token.line, BINOPS[current_token.value]
 
   while binop && binop.prec >= min_prec {
-    if BITOPS[binop.token] && (lua_target == '5.1+' || lua_target == '5.2+') && !bitlib {
-      throw('must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+', binop_line)
+    if BITOPS[binop.token] && (lua_target == '5.1+' || lua_target == '5.2+') && !bitexpr {
+      throw('must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+', binop_line)
     }
 
     consume()
@@ -1495,8 +1495,8 @@ local function variable_assignment(first_id) {
 
   local op_line, op_token = current_token.line, BINOP_ASSIGNMENT_TOKENS[current_token.value] && consume()
 
-  if BITOPS[op_token] && (lua_target == '5.1+' || lua_target == '5.2+') && !bitlib {
-    throw('must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+', op_line)
+  if BITOPS[op_token] && (lua_target == '5.1+' || lua_target == '5.2+') && !bitexpr {
+    throw('must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+', op_line)
   }
 
   expect('=', true)
@@ -1705,10 +1705,13 @@ return (source, options = {}) -> {
   goto_labels = {}
   alias = options.alias || get_source_alias(source)
   lua_target = options.lua_target || config.lua_target
-  bitlib = options.bitlib || config.bitlib
-    || (lua_target == '5.1' && 'bit') -- Mike Pall's LuaBitOp
-    || (lua_target == 'jit' && 'bit') -- Mike Pall's LuaBitOp
-    || (lua_target == '5.2' && 'bit32') -- Lua 5.2's builtin bit32 library
+
+  local bitlib = options.bitlib || config.bitlib
+  bitexpr = options.bitexpr || config.bitexpr
+    || (bitlib && "require('{ bitlib }')")
+    || (lua_target == '5.1' && "require('bit')") -- Mike Pall's LuaBitOp
+    || (lua_target == 'jit' && 'bit') -- Mike Pall's LuaBitOp (global)
+    || (lua_target == '5.2' && 'bit32') -- Lua 5.2's builtin bit32 library (global)
 
   local source_map = {}
   local compile_lines = {}

--- a/erde/compile.erde
+++ b/erde/compile.erde
@@ -1706,6 +1706,10 @@ return (source, options = {}) -> {
   alias = options.alias || get_source_alias(source)
   lua_target = options.lua_target || config.lua_target
 
+  if options.bitlib {
+    print("WARNING: `bitlib` has been deprecated in favor of `bitexpr`.")
+  }
+
   local bitlib = options.bitlib || config.bitlib
   bitexpr = options.bitexpr || config.bitexpr
     || (bitlib && "require('{ bitlib }')")

--- a/erde/compile.lua
+++ b/erde/compile.lua
@@ -1374,6 +1374,9 @@ return function(source, options)
 	goto_labels = {}
 	alias = options.alias or get_source_alias(source)
 	lua_target = options.lua_target or config.lua_target
+	if options.bitlib then
+		print("WARNING: `bitlib` has been deprecated in favor of `bitexpr`.")
+	end
 	local bitlib = options.bitlib or config.bitlib
 	bitexpr = options.bitexpr
 		or config.bitexpr
@@ -1388,10 +1391,10 @@ return function(source, options)
 		source_map = source_map,
 		source_line = current_token.line,
 	})
-	for _, __ERDE_TMP_1933__ in ipairs(goto_jumps) do
+	for _, __ERDE_TMP_1936__ in ipairs(goto_jumps) do
 		local label, line
-		label = __ERDE_TMP_1933__.label
-		line = __ERDE_TMP_1933__.line
+		label = __ERDE_TMP_1936__.label
+		line = __ERDE_TMP_1936__.line
 		if goto_labels[label] == nil then
 			throw("failed to find goto label '" .. tostring(label) .. "'", line)
 		end

--- a/erde/compile.lua
+++ b/erde/compile.lua
@@ -38,7 +38,7 @@ local block_declarations, block_declaration_stack
 local goto_jumps, goto_labels
 local alias
 local lua_target
-local bitlib
+local bitexpr
 local function throw(message, line)
 	if line == nil then
 		line = current_token.line
@@ -170,10 +170,10 @@ local function compile_binop(op_token, op_line, lhs, rhs)
 			rhs,
 			")",
 		}
-	elseif bitlib and BITOPS[op_token] then
+	elseif bitexpr and BITOPS[op_token] then
 		return {
 			op_line,
-			"(require('" .. tostring(bitlib) .. "')." .. tostring(BITLIB_METHODS[op_token]) .. "(",
+			"((" .. tostring(bitexpr) .. ")." .. tostring(BITLIB_METHODS[op_token]) .. "(",
 			lhs,
 			",",
 			rhs,
@@ -898,15 +898,15 @@ local function unop_expression()
 			unop.token,
 			operand,
 		}
-	elseif bitlib then
+	elseif bitexpr then
 		return {
 			unop_line,
-			"(require('" .. tostring(bitlib) .. "').bnot(",
+			"((" .. tostring(bitexpr) .. ").bnot(",
 			operand,
 			"))",
 		}
 	elseif lua_target == "5.1+" or lua_target == "5.2+" then
-		throw("must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+", unop_line)
+		throw("must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+", unop_line)
 	else
 		return {
 			unop_line,
@@ -925,8 +925,8 @@ function expression(min_prec)
 	local compile_lines = UNOPS[current_token.value] and unop_expression() or terminal_expression()
 	local binop_line, binop = current_token.line, BINOPS[current_token.value]
 	while binop and binop.prec >= min_prec do
-		if BITOPS[binop.token] and (lua_target == "5.1+" or lua_target == "5.2+") and not bitlib then
-			throw("must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+", binop_line)
+		if BITOPS[binop.token] and (lua_target == "5.1+" or lua_target == "5.2+") and not bitexpr then
+			throw("must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+", binop_line)
 		end
 		consume()
 		if binop.token == "~" and current_token.value == "=" then
@@ -1211,8 +1211,8 @@ local function variable_assignment(first_id)
 		table.insert(ids, id)
 	end
 	local op_line, op_token = current_token.line, BINOP_ASSIGNMENT_TOKENS[current_token.value] and consume()
-	if BITOPS[op_token] and (lua_target == "5.1+" or lua_target == "5.2+") and not bitlib then
-		throw("must specify bitlib for compiling bit operations when targeting 5.1+ or 5.2+", op_line)
+	if BITOPS[op_token] and (lua_target == "5.1+" or lua_target == "5.2+") and not bitexpr then
+		throw("must specify bitexpr or bitlib for compiling bit operations when targeting 5.1+ or 5.2+", op_line)
 	end
 	expect("=", true)
 	local expressions = list(expression)
@@ -1374,9 +1374,11 @@ return function(source, options)
 	goto_labels = {}
 	alias = options.alias or get_source_alias(source)
 	lua_target = options.lua_target or config.lua_target
-	bitlib = options.bitlib
-		or config.bitlib
-		or (lua_target == "5.1" and "bit")
+	local bitlib = options.bitlib or config.bitlib
+	bitexpr = options.bitexpr
+		or config.bitexpr
+		or (bitlib and "require('" .. tostring(bitlib) .. "')")
+		or (lua_target == "5.1" and "require('bit')")
 		or (lua_target == "jit" and "bit")
 		or (lua_target == "5.2" and "bit32")
 	local source_map = {}
@@ -1386,10 +1388,10 @@ return function(source, options)
 		source_map = source_map,
 		source_line = current_token.line,
 	})
-	for _, __ERDE_TMP_1927__ in ipairs(goto_jumps) do
+	for _, __ERDE_TMP_1933__ in ipairs(goto_jumps) do
 		local label, line
-		label = __ERDE_TMP_1927__.label
-		line = __ERDE_TMP_1927__.line
+		label = __ERDE_TMP_1933__.label
+		line = __ERDE_TMP_1933__.line
 		if goto_labels[label] == nil then
 			throw("failed to find goto label '" .. tostring(label) .. "'", line)
 		end

--- a/erde/config.erde
+++ b/erde/config.erde
@@ -5,6 +5,9 @@ module lua_target = '5.1+'
 -- precise error rewriting.
 module is_cli_runtime = false
 
+-- User specified expression to use for bit operations.
+module bitexpr = nil
+
 -- User specified library to use for bit operations.
 module bitlib = nil
 

--- a/erde/config.lua
+++ b/erde/config.lua
@@ -1,6 +1,7 @@
 local _MODULE = {}
 _MODULE.lua_target = "5.1+"
 _MODULE.is_cli_runtime = false
+_MODULE.bitexpr = nil
 _MODULE.bitlib = nil
 _MODULE.disable_source_maps = false
 return _MODULE


### PR DESCRIPTION
This PR introduces `bitexpr`, which is similar to `bitlib` except it allows arbitrary expressions instead of only `require` names. It is strictly more powerful than `bitlib`, hence why `bitlib` has been marked as deprecated in favor of `bitexpr`.

`bitexpr` is settable both via the CLI (`--bitexpr`) and programmatically via the compile options:

```bash
erde --bitexpr "require('bit')" compile myfile.erde
```

```erde
local erde = require('erde')

erde.compile("...", {
  bitexpr = "require('bit')",
})
```

Closes https://github.com/erde-lang/erde/issues/38